### PR TITLE
solo/lb-build

### DIFF
--- a/Makefile.lb
+++ b/Makefile.lb
@@ -1,0 +1,28 @@
+include $(WORKSPACE_TOP)/common/Makefile.env
+
+REPO=sedutil
+COMP=sedutil
+
+SEDUTIL_INSTALL_DIR ?= $(shell component-tool localpath --repo=$(REPO) --type=$(BUILD_TYPE) $(COMP))
+
+BIN=sedutil-cli
+
+.PHONY: all build install checkin clean
+
+all: build
+
+build:
+	$(Q)autoreconf -i
+	$(Q)./configure
+	$(Q)$(MAKE) config.h linux/Version.h $(BIN)
+	$(Q)rm linux/Version.h
+
+install:
+	$(Q)mkdir -p $(SEDUTIL_INSTALL_DIR)
+	$(Q)cp $(BIN) $(SEDUTIL_INSTALL_DIR)/
+
+checkin:
+	$(Q)component-tool checkin -v --repo=$(REPO) --type=$(BUILD_TYPE) $(COMP)
+
+clean:
+	$(Q)$(MAKE) distclean

--- a/Makefile.lb
+++ b/Makefile.lb
@@ -13,7 +13,7 @@ all: build
 
 build:
 	$(Q)autoreconf -i
-	$(Q)./configure
+	$(Q)LDFLAGS=-static ./configure
 	$(Q)$(MAKE) config.h linux/Version.h $(BIN)
 	$(Q)rm linux/Version.h
 

--- a/lb.yaml
+++ b/lb.yaml
@@ -1,0 +1,16 @@
+sedutil:
+  sedutil:
+    build:
+      - make -f Makefile.lb build
+    install:
+      - make -f Makefile.lb install
+    checkin:
+      - make -f Makefile.lb checkin
+    deps:
+      - file://Common
+      - file://debian
+      - file://linux
+      - file://lb.yaml
+      - file://Makefile.lb
+      - file://configure.ac
+      - file://Makefile.am


### PR DESCRIPTION
integrate with `lb-build`, make `sedutil-cli` a static binary so it'll run on all the relevant systems.

the two primary use cases are the SED qualification systest and validation systests, although i suspect it's a damn sight better solution than committing a [random binary](https://github.com/LightBitsLabs/inaugurator/commit/21e4e2b192ad70eba2545b4986797a3f9b23c972) into a source code repository too...